### PR TITLE
Update operators.yaml

### DIFF
--- a/misc4.0/ServiceMesh/operators.yaml
+++ b/misc4.0/ServiceMesh/operators.yaml
@@ -40,7 +40,7 @@ metadata:
   name: "service-mesh-operator"
   namespace: "openshift-operators" 
 spec:
-  channel: "1.0" 
+  channel: "stable" 
   installPlanApproval: "Automatic"
   source: "redhat-operators"
   sourceNamespace: "openshift-marketplace" 


### PR DESCRIPTION
Don't use 1.0 channel -- deprecated and only exists to support those who originally installed SM using the 1.0 channel