### PR TITLE
Update nfd-discovery.yaml

### DIFF
--- a/misc4.0/gpu/nfd-discovery.yaml
+++ b/misc4.0/gpu/nfd-discovery.yaml
@@ -2,5 +2,5 @@ apiVersion: nfd.openshift.io/v1alpha1
 kind: NodeFeatureDiscovery
 metadata:
   name: nfd-master-server
-spec:
-  namespace: openshift-nfd
+  namespace: openshift-operators
+spec: {}


### PR DESCRIPTION
namespace belongs in the metadata, not spec